### PR TITLE
Pass buffer as HMAC secret key when signing

### DIFF
--- a/lib/Response.js
+++ b/lib/Response.js
@@ -38,7 +38,7 @@ Response.prototype.sign = function(hashAlgorithm, secretBuffer) {
 
   //sign the form
   var form = this.toForm();
-  var hmac = crypto.createHmac(hashAlgorithm, secretBuffer.toString('binary'));
+  var hmac = crypto.createHmac(hashAlgorithm, secretBuffer);
   hmac.update(form, 'utf8');
 
   //add the new fields


### PR DESCRIPTION
- On Node v6+, the binary string buffer encoding breaks tests for signing responses.
- The problem is possibly due to [breaking changes in the `crypto` library made between Node v5 and v6](https://github.com/nodejs/node/wiki/Breaking-changes-between-v5-and-v6#crypto).
- This fix was tested, and works, on Node v0.12, v4, v5, v6, v7.